### PR TITLE
Make the `tf` command cross-platform

### DIFF
--- a/tfs.js
+++ b/tfs.js
@@ -19,7 +19,7 @@ var fs = require('fs'),
         workspace: "",
         login: "" // /login:username@domain,password
     };
-    tfAdress = fs.realpathSync(".\\tf\\tf.cmd"),
+    tfAdress = fs.realpathSync(".\\tf\\tf"),
     msg = {
         "cmd": {
             "startCommand": "Start cmd command",


### PR DESCRIPTION
If the extension is left off, this library will wok for POSIX systems, as well as Windows.
